### PR TITLE
Improve SEO defaults

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export const LANGUAGE = "ja";
 export const AUTHOR = "tosakax2";
 
 export const SEO_DEFAULTS = {
-  title: SITE_TITLE,
+  titleDefault: SITE_TITLE,
   titleTemplate: "%s - " + SITE_TITLE,
   description: SITE_DESCRIPTION,
   openGraph: {
@@ -18,6 +18,9 @@ export const SEO_DEFAULTS = {
     optional: {
       description: SITE_DESCRIPTION,
     },
+    image: {
+      alt: "T2-Lab default image",
+    },
   },
   twitter: {
     site: "@tosakax2",
@@ -26,5 +29,6 @@ export const SEO_DEFAULTS = {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     image: `${SITE_URL}/images/default-image.png`,
+    imageAlt: "T2-Lab default image",
   },
 };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
 import { SEO } from "astro-seo";
-import { LANGUAGE , SITE_TITLE, SITE_URL, SEO_DEFAULTS} from "../config";
+import { LANGUAGE , SITE_TITLE, SEO_DEFAULTS } from "../config";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import "../styles/global.css";
@@ -10,20 +10,26 @@ const { pageTitle, seo: pageSeo = {} } = Astro.props;
 
 const seoProps = {
   ...SEO_DEFAULTS,
+  ...pageSeo,
   title: pageSeo.title || pageTitle,
   openGraph: {
     ...SEO_DEFAULTS.openGraph,
+    ...(pageSeo.openGraph ?? {}),
     basic: {
       ...SEO_DEFAULTS.openGraph.basic,
+      ...(pageSeo.openGraph?.basic ?? {}),
       title: `${pageSeo.title || pageTitle} - ${SITE_TITLE}`,
-      url: `${SITE_URL}${Astro.url.pathname}`,
+    },
+    image: {
+      ...SEO_DEFAULTS.openGraph.image,
+      ...(pageSeo.openGraph?.image ?? {}),
     },
   },
   twitter: {
     ...SEO_DEFAULTS.twitter,
+    ...(pageSeo.twitter ?? {}),
     title: `${pageSeo.title || pageTitle} - ${SITE_TITLE}`,
   },
-  ...pageSeo,
 };
 ---
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,10 +4,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 const pageTitle = "404 Not Found";
 ---
 
-<BaseLayout pageTitle={pageTitle}>
-  <head>
-    <meta name="robots" content="noindex" />
-  </head>
+<BaseLayout pageTitle={pageTitle} seo={{ noindex: true }}>
   <div class="flex flex-1 flex-col items-center justify-center p-8">
     <div  
       class="w-32 h-32"


### PR DESCRIPTION
## Summary
- refine SEO default options
- merge SEO props correctly in `BaseLayout`
- configure 404 page to use `noindex`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877638c78d083298dd6582f55f7b038