### PR TITLE
Add canonical URL to SEO props

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,6 @@ export const SEO_DEFAULTS = {
       title: SITE_TITLE,
       type: "website",
       image: `${SITE_URL}/images/default-image.png`,
-      url: SITE_URL,
     },
     optional: {
       description: SITE_DESCRIPTION,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,12 +1,13 @@
 ---
 import { SEO } from "astro-seo";
-import { LANGUAGE , SITE_TITLE, SEO_DEFAULTS } from "../config";
+import { LANGUAGE , SITE_TITLE, SITE_URL, SEO_DEFAULTS } from "../config";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import "../styles/global.css";
 import "../styles/remark-link-card.css"
 
 const { pageTitle, seo: pageSeo = {} } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, SITE_URL).toString();
 
 const seoProps = {
   ...SEO_DEFAULTS,
@@ -19,6 +20,7 @@ const seoProps = {
       ...SEO_DEFAULTS.openGraph.basic,
       ...(pageSeo.openGraph?.basic ?? {}),
       title: `${pageSeo.title || pageTitle} - ${SITE_TITLE}`,
+      url: canonicalURL,
     },
     image: {
       ...SEO_DEFAULTS.openGraph.image,
@@ -29,7 +31,9 @@ const seoProps = {
     ...SEO_DEFAULTS.twitter,
     ...(pageSeo.twitter ?? {}),
     title: `${pageSeo.title || pageTitle} - ${SITE_TITLE}`,
+    url: canonicalURL,
   },
+  canonicalURL,
 };
 ---
 


### PR DESCRIPTION
## Summary
- compute canonical URL in `BaseLayout.astro`
- include canonical URL for Open Graph and Twitter
- remove default Open Graph URL from `SEO_DEFAULTS`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68776a2dfaac832982e671da85f29e41