### PR TITLE
Update SEO titles

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,7 +19,7 @@ const seoProps = {
     basic: {
       ...SEO_DEFAULTS.openGraph.basic,
       ...(pageSeo.openGraph?.basic ?? {}),
-      title: `${pageSeo.title || pageTitle} - ${SITE_TITLE}`,
+      title: pageSeo.title || pageTitle,
       url: canonicalURL,
     },
     image: {
@@ -30,7 +30,7 @@ const seoProps = {
   twitter: {
     ...SEO_DEFAULTS.twitter,
     ...(pageSeo.twitter ?? {}),
-    title: `${pageSeo.title || pageTitle} - ${SITE_TITLE}`,
+    title: pageSeo.title || pageTitle,
     url: canonicalURL,
   },
   canonicalURL,


### PR DESCRIPTION
## Summary
- ensure OpenGraph and Twitter titles use the page title directly

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68777067736483299f93d35bfa61b268