### PR TITLE
Add blog pagination

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,40 @@
+---
+export interface Props {
+  current: number;
+  total: number;
+  baseUrl: string; // e.g. '/blog/page'
+}
+const { current, total, baseUrl } = Astro.props as Props;
+const pages = Array.from({ length: total }, (_, i) => i + 1);
+---
+{total > 1 && (
+  <nav class="flex justify-center mt-8">
+    <ul class="flex flex-wrap items-center gap-2">
+      {current > 1 && (
+        <li>
+          <a href={`${baseUrl}/${current - 1}`} class="px-3 py-1 border border-[var(--color-border)] rounded transition-colors duration-200 hover:border-[var(--color-accent)]">
+            Prev
+          </a>
+        </li>
+      )}
+      {pages.map(page => (
+        <li>
+          {page === current ? (
+            <span class="px-3 py-1 font-bold border border-[var(--color-accent)] text-[var(--color-accent)] rounded">{page}</span>
+          ) : (
+            <a href={`${baseUrl}/${page}`} class="px-3 py-1 border border-[var(--color-border)] rounded transition-colors duration-200 hover:border-[var(--color-accent)]">
+              {page}
+            </a>
+          )}
+        </li>
+      ))}
+      {current < total && (
+        <li>
+          <a href={`${baseUrl}/${current + 1}`} class="px-3 py-1 border border-[var(--color-border)] rounded transition-colors duration-200 hover:border-[var(--color-accent)]">
+            Next
+          </a>
+        </li>
+      )}
+    </ul>
+  </nav>
+)}

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import PostList from "../components/PostList.astro";
+import Pagination from "../components/Pagination.astro";
 import { hashTitle } from "../utils/hashTitle";
 
 // Markdownファイルを全部取得
@@ -35,14 +36,21 @@ const posts = Object.entries(postFiles).map(([path, mod]) => {
 // 任意: 日付で降順ソート
 posts.sort((a, b) => b.frontmatter.date.localeCompare(a.frontmatter.date));
 
+const PER_PAGE = 10;
 const pageTitle = "Blog";
+const totalPages = Math.ceil(posts.length / PER_PAGE);
+const currentPage = 1;
+const paginated = posts.slice(0, PER_PAGE);
 ---
 
 <BaseLayout pageTitle={pageTitle}>
   <div class="max-w-3xl mx-auto px-4 sm:px-8 py-16 w-full">
     <h1 data-scramble class="text-center text-4xl font-bold mb-16">{pageTitle}</h1>
     <section>
-      <PostList posts={posts} />
+      <PostList posts={paginated} />
+      {totalPages > 1 && (
+        <Pagination current={currentPage} total={totalPages} baseUrl="/blog/page" />
+      )}
     </section>
   </div>
 </BaseLayout>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -5,10 +5,10 @@ import PostList from "../../../components/PostList.astro";
 import Pagination from "../../../components/Pagination.astro";
 import { hashTitle } from "../../../utils/hashTitle";
 
-const PER_PAGE = 10;
+const PER_PAGE = 5;
 
 export async function getStaticPaths() {
-  const PER_PAGE = 10;
+  const PER_PAGE = 5;
   const postFiles = import.meta.glob('../../../blog/*.{md,mdx}', { eager: true });
   const total = Object.keys(postFiles).length;
   const totalPages = Math.ceil(total / PER_PAGE);

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -1,0 +1,53 @@
+---
+export interface Params { page: string }
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import PostList from "../../../components/PostList.astro";
+import Pagination from "../../../components/Pagination.astro";
+import { hashTitle } from "../../../utils/hashTitle";
+
+const PER_PAGE = 10;
+
+export async function getStaticPaths() {
+  const PER_PAGE = 10;
+  const postFiles = import.meta.glob('../../../blog/*.{md,mdx}', { eager: true });
+  const total = Object.keys(postFiles).length;
+  const totalPages = Math.ceil(total / PER_PAGE);
+  return Array.from({ length: totalPages }, (_, i) => ({ params: { page: String(i + 1) } }));
+}
+
+const { page } = Astro.params as Params;
+const currentPage = Number(page);
+const postFiles = import.meta.glob('../../../blog/*.{md,mdx}', { eager: true });
+const posts = Object.entries(postFiles).map(([path, mod]) => {
+  const typedMod = mod as {
+    frontmatter: {
+      title: string;
+      date: string;
+      description?: string;
+      slug?: string;
+      categories?: string[];
+      tags?: string[];
+    };
+    Content: any;
+  };
+  const date = typedMod.frontmatter.date.replace(/-/g, '').slice(0, 8);
+  const hash = hashTitle(typedMod.frontmatter.title);
+  const slug = typedMod.frontmatter.slug || `${date}-${hash}`;
+  return { ...typedMod, url: `/blog/${slug}`, slug };
+});
+posts.sort((a, b) => b.frontmatter.date.localeCompare(a.frontmatter.date));
+
+const totalPages = Math.ceil(posts.length / PER_PAGE);
+const paginated = posts.slice((currentPage - 1) * PER_PAGE, currentPage * PER_PAGE);
+
+const pageTitle = `Blog - Page ${currentPage}`;
+---
+<BaseLayout pageTitle={pageTitle}>
+  <div class="max-w-3xl mx-auto px-4 sm:px-8 py-16 w-full">
+    <h1 data-scramble class="text-center text-4xl font-bold mb-16">Blog</h1>
+    <section>
+      <PostList posts={paginated} />
+      <Pagination current={currentPage} total={totalPages} baseUrl="/blog/page" />
+    </section>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- implement `Pagination` component
- paginate blog list view at `/blog`
- add dynamic pages under `/blog/page/[page]`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879eb29c2848329a005cb7ac90b502b